### PR TITLE
fixed render target for hdr camera as a cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,13 @@ repository = "https://github.com/torsteingrindvik/bevy-vfx-bag"
 
 exclude = [".github/", "scripts/"]
 
+[features]
+
+default = ["sdr"]
+
+hdr = []
+sdr = []
+
 [dependencies]
 bevy = { version = "0.10", default-features = false, features = [
     "bevy_asset",

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -175,7 +175,12 @@ pub(crate) fn render_pipeline_descriptor(
             shader,
             shader_defs,
             entry_point: "fragment".into(),
+
+            #[cfg(feature = "sdr")]
             targets: vec![Some(TextureFormat::bevy_default().into())],
+
+            #[cfg(feature = "hdr")]
+            targets: vec![Some(ViewTarget::TEXTURE_FORMAT_HDR.into())],
         }),
         push_constant_ranges: vec![],
     }


### PR DESCRIPTION
If `Camera` has `hdr: true` the default texture format for render target doesnt work so i had to change it from `TextureFormat::bevy_default()` to `ViewTarget::TEXTURE_FORMAT_HDR`. Probably better to do this in runtime but i didn't see a quick way to get either camera or a view to ping for `.hdr`. 