### PR TITLE
added fading for masks to be able to hide/show them smoothly

### DIFF
--- a/assets/shaders/masks.wgsl
+++ b/assets/shaders/masks.wgsl
@@ -10,6 +10,7 @@ var<uniform> globals: Globals;
 
 struct Mask {
     strength: f32,
+    fade: f32,
 };
 @group(1) @binding(0)
 var<uniform> mask: Mask;
@@ -24,7 +25,7 @@ fn square(uv: vec2<f32>) -> f32 {
     let uv_big = saturate(uv * mask.strength);
     let uv_big_inv = saturate((1. - uv) * mask.strength);
 
-    // By multiplying the mirrored borders we can get a full border. 
+    // By multiplying the mirrored borders we can get a full border.
     let square = uv_big * uv_big_inv;
 
     // The border is made by saturing UV coordinates.
@@ -84,5 +85,5 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let result = vignette(in.uv);
     #endif
 
-    return vec4<f32>(sample.rgb * result, 1.0);
+    return vec4<f32>(sample.rgb * saturate(result + mask.fade), 1.0);
 }

--- a/examples/masks/main.rs
+++ b/examples/masks/main.rs
@@ -61,6 +61,8 @@ fn update(keyboard_input: Res<Input<KeyCode>>, mut query: Query<&mut Mask, With<
         mask.fade -= 0.01;
     };
 
+    mask.fade = mask.fade.clamp(0.0, 1.0);
+
     // Let user go to low- and high strength values directly via L and H keys
     let low = || match mask.variant {
         MaskVariant::Square => 3.,

--- a/examples/masks/main.rs
+++ b/examples/masks/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn startup(mut commands: Commands) {
-    info!("Press [1|2|3] to change which mask is in use, [Up|Down] to change strenght, [L|H] to go low/high");
+    info!("Press [1|2|3] to change which mask is in use, [Up|Down] to change strenght, [L|H] to go low/high [PgUp/PgDown] to fade in/out the mask");
 
     commands
         .spawn(Camera3dBundle {
@@ -53,6 +53,12 @@ fn update(keyboard_input: Res<Input<KeyCode>>, mut query: Query<&mut Mask, With<
         mask.strength += increment();
     } else if keyboard_input.pressed(KeyCode::Down) {
         mask.strength -= increment();
+    };
+
+    if keyboard_input.pressed(KeyCode::PageUp) {
+        mask.fade += 0.01;
+    } else if keyboard_input.pressed(KeyCode::PageDown) {
+        mask.fade -= 0.01;
     };
 
     // Let user go to low- and high strength values directly via L and H keys

--- a/src/post_processing/masks.rs
+++ b/src/post_processing/masks.rs
@@ -211,13 +211,20 @@ pub struct Mask {
     /// Run the masks example to experiment with these values interactively.
     pub strength: f32,
 
+    /// How much the mask is faded: 1.0 - mask has no effect, 0.0 - mask is in full effect
+    pub fade: f32,
+
     /// Which [`MaskVariant`] to produce.
     pub variant: MaskVariant,
 }
 
 impl Display for Mask {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Mask {:?}, strength: {}", self.variant, self.strength)
+        write!(
+            f,
+            "Mask {:?}, strength: {} fade: {}",
+            self.variant, self.strength, self.fade
+        )
     }
 }
 
@@ -226,6 +233,7 @@ impl Mask {
     pub fn square() -> Self {
         Self {
             strength: 20.,
+            fade: 0.,
             variant: MaskVariant::Square,
         }
     }
@@ -234,6 +242,7 @@ impl Mask {
     pub fn crt() -> Self {
         Self {
             strength: 80000.,
+            fade: 0.,
             variant: MaskVariant::Crt,
         }
     }
@@ -242,6 +251,7 @@ impl Mask {
     pub fn vignette() -> Self {
         Self {
             strength: 0.66,
+            fade: 0.,
             variant: MaskVariant::Vignette,
         }
     }
@@ -258,12 +268,14 @@ impl Default for Mask {
 #[derive(Debug, ShaderType, Clone, Component, Copy)]
 pub struct MaskUniform {
     pub(crate) strength: f32,
+    pub(crate) fade: f32,
 }
 
 impl From<Mask> for MaskUniform {
     fn from(mask: Mask) -> Self {
         Self {
             strength: mask.strength,
+            fade: mask.fade,
         }
     }
 }


### PR DESCRIPTION
I needed a way to smoothly hide/reveal the mask effect with animation and mask.strength (for crt) wont allow to completely remove the effect from screen even with very high values. So I've added 'fade' to achieve that.
gif with fade:
![fade](https://github.com/torsteingrindvik/bevy-vfx-bag/assets/668981/2a2afbfc-fbad-42a4-846f-efb9ff15d482)
gif with strength:
![strength](https://github.com/torsteingrindvik/bevy-vfx-bag/assets/668981/88dad73c-e4db-45ab-b9e1-e455ff9fbccc)
