### PR TITLE
Fix WASM size issues

### DIFF
--- a/assets/shaders/blur.wgsl
+++ b/assets/shaders/blur.wgsl
@@ -10,7 +10,9 @@ var<uniform> globals: Globals;
 
 struct Blur {
     amount: f32,
-    kernel_radius: f32
+    kernel_radius: f32,
+    
+    _padding: vec2<f32>,
 };
 @group(1) @binding(0)
 var<uniform> blur: Blur;

--- a/assets/shaders/flip.wgsl
+++ b/assets/shaders/flip.wgsl
@@ -11,6 +11,8 @@ var<uniform> globals: Globals;
 struct Flip {
     x: f32,
     y: f32,
+
+    _padding: vec2<f32>,
 };
 @group(1) @binding(0)
 var<uniform> flip: Flip;

--- a/assets/shaders/pixelate.wgsl
+++ b/assets/shaders/pixelate.wgsl
@@ -10,6 +10,8 @@ var<uniform> globals: Globals;
 
 struct Pixelate {
     block_size: f32,
+    
+    _padding: vec3<f32>,
 };
 @group(1) @binding(0)
 var<uniform> pixelate: Pixelate;

--- a/assets/shaders/raindrops.wgsl
+++ b/assets/shaders/raindrops.wgsl
@@ -11,7 +11,9 @@ var<uniform> globals: Globals;
 struct Raindrops {
     time_scaling: f32,
     intensity: f32,
-    zoom: f32
+    zoom: f32,
+    
+    _padding: f32,
 };
 
 @group(1) @binding(0)

--- a/assets/shaders/wave.wgsl
+++ b/assets/shaders/wave.wgsl
@@ -17,7 +17,9 @@ struct Wave {
     speed_y: f32,
 
     amplitude_x: f32,
-    amplitude_y: f32
+    amplitude_y: f32,
+
+    _padding: vec2<f32>,
 };
 
 @group(1) @binding(0)

--- a/src/post_processing/blur.rs
+++ b/src/post_processing/blur.rs
@@ -139,6 +139,9 @@ pub struct Blur {
     /// when blurring.
     /// This is in UV coordinates, so small (positive) values are expected (`0.01` is a good start).
     pub kernel_radius: f32,
+
+    /// Padding.
+    pub _padding: Vec2,
 }
 
 impl Default for Blur {
@@ -146,6 +149,7 @@ impl Default for Blur {
         Self {
             amount: 0.5,
             kernel_radius: 0.01,
+            _padding: Vec2::ZERO,
         }
     }
 }

--- a/src/post_processing/flip.rs
+++ b/src/post_processing/flip.rs
@@ -134,18 +134,23 @@ fn queue(
 pub struct FlipUniform {
     pub(crate) x: f32,
     pub(crate) y: f32,
+    pub(crate) _padding: Vec2,
 }
 
 impl From<Flip> for FlipUniform {
     fn from(flip: Flip) -> Self {
         let uv = match flip {
-            Flip::None => [0.0, 0.0],
-            Flip::Horizontal => [1.0, 0.0],
-            Flip::Vertical => [0.0, 1.0],
-            Flip::HorizontalVertical => [1.0, 1.0],
+            Flip::None => (0.0, 0.0),
+            Flip::Horizontal => (1.0, 0.0),
+            Flip::Vertical => (0.0, 1.0),
+            Flip::HorizontalVertical => (1.0, 1.0),
         };
 
-        Self { x: uv[0], y: uv[1] }
+        Self {
+            x: uv.0,
+            y: uv.1,
+            _padding: Vec2::ZERO,
+        }
     }
 }
 

--- a/src/post_processing/pixelate.rs
+++ b/src/post_processing/pixelate.rs
@@ -141,11 +141,17 @@ pub struct Pixelate {
     ///
     /// The shader sets a lower bound to 1.0, since that would not change the outcome.
     pub block_size: f32,
+
+    /// Padding.
+    pub _padding: Vec3,
 }
 
 impl Default for Pixelate {
     fn default() -> Self {
-        Self { block_size: 8.0 }
+        Self {
+            block_size: 8.0,
+            _padding: Vec3::ZERO,
+        }
     }
 }
 

--- a/src/post_processing/raindrops.rs
+++ b/src/post_processing/raindrops.rs
@@ -224,6 +224,9 @@ pub struct Raindrops {
 
     /// How zoomed in the raindrops texture is.
     pub zoom: f32,
+
+    /// Padding.
+    pub _padding: f32,
 }
 
 impl Default for Raindrops {
@@ -232,6 +235,7 @@ impl Default for Raindrops {
             speed: 0.8,
             warping: 0.03,
             zoom: 1.0,
+            _padding: 0.0,
         }
     }
 }

--- a/src/post_processing/wave.rs
+++ b/src/post_processing/wave.rs
@@ -50,6 +50,9 @@ pub struct Wave {
 
     /// How much displacement the y axis waves cause.
     pub amplitude_y: f32,
+
+    /// Padding.
+    pub _padding: Vec2,
 }
 
 #[derive(Resource)]


### PR DESCRIPTION
WGPU seems to want input types to be a multiple of 16 on WASM. This may not be the desirable approach, but it's a start. 